### PR TITLE
Moved tempo from being hardcoded in MidiService to being configurable…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ val musicService: MusicService = new MusicService(soundfontPath)
 You must also declare a starting [Context](src/main/scala/scalamusic/performance/Context.scala) for your music:
 
 ```scala
-val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Metronome.tickedWholeNote(96), 0, 127, (C, Mode.Major))
+val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Metronome.tickedWholeNote(96), 0, 127, 127, (C, Mode.Major), timeSignature, 120)
 ```
 
-The context define things like the starting speed, instrument, the player that will perform the music, and more.
+The context defines things like the starting tempo (in BPM), instrument, the player that will perform the music, volume, and more.
 
 You have to attach a context to each of your musics, defining the parts that make the music score:
 

--- a/src/main/scala/scalamusic/audio/MidiService.scala
+++ b/src/main/scala/scalamusic/audio/MidiService.scala
@@ -92,7 +92,6 @@ object MidiService {
           for (ev <- events) {
             track.add(ev)
           }
-          // TODO let it be conditionally added
           // Add a meta event to indicate the end of the track.
           // The track will end one whole note after the ticked length of the track, so the sound is allowed to fade.
           val msg = new MetaMessage(MidiUtils.META_END_OF_TRACK_TYPE, Array[Byte](0), 0)

--- a/src/main/scala/scalamusic/examples/Mambo.scala
+++ b/src/main/scala/scalamusic/examples/Mambo.scala
@@ -17,7 +17,7 @@ object Mambo extends App {
   val musicService: MusicService = new MusicService(soundfontPath)
   val repetitions: Int = 8
   val timeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
-  val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Meter.tickedWholeNote(96), 0, 127, 127, (C, Mode.Major), timeSignature, 184)
+  val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Meter.tickedWholeNote(96), 0, 127, 127, (C, Mode.Major), timeSignature, 175)
 
   val piano: Music[Pitch] = (
     (c(5, qn) :=: c(4, qn) :=: c(3, qn)) :+:

--- a/src/main/scala/scalamusic/examples/Mambo.scala
+++ b/src/main/scala/scalamusic/examples/Mambo.scala
@@ -17,7 +17,7 @@ object Mambo extends App {
   val musicService: MusicService = new MusicService(soundfontPath)
   val repetitions: Int = 8
   val timeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
-  val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Meter.tickedWholeNote(96), 0, 127, 127, (C, Mode.Major), timeSignature)
+  val context: Context[NoteWithAttributes] = Context(0, DefaultPlayer, AcousticGrandPiano, Meter.tickedWholeNote(96), 0, 127, 127, (C, Mode.Major), timeSignature, 184)
 
   val piano: Music[Pitch] = (
     (c(5, qn) :=: c(4, qn) :=: c(3, qn)) :+:

--- a/src/main/scala/scalamusic/performance/Context.scala
+++ b/src/main/scala/scalamusic/performance/Context.scala
@@ -18,6 +18,7 @@ import scalamusic.performance.players.Player
   * @param cVol    current volume 0-127
   * @param cKey    current key
   * @param cTimeSignature  current time signature
+  * @param cTempo  current tempo in BPM (beats per minute)
   * @tparam A
   */
 case class Context[A](
@@ -29,5 +30,6 @@ case class Context[A](
     cVel: Velocity,
     cVol: Volume,
     cKey: (PitchClass, Mode),
-    cTimeSignature: TimeSignature
+    cTimeSignature: TimeSignature,
+    cTempo: Int
 )

--- a/src/main/scala/scalamusic/performance/MusicEvent.scala
+++ b/src/main/scala/scalamusic/performance/MusicEvent.scala
@@ -12,6 +12,7 @@ import scalamusic.performance.Performance.{TickedDuration, TickedTime}
   * @param eDur    note duration in ticks
   * @param eVol    volume value 0-127
   * @param eParams optional other parameters
+  * @param eTempo  tempo in BPM (beats per minute)
   */
 case class MusicEvent(
     eTime: TickedTime,
@@ -20,5 +21,6 @@ case class MusicEvent(
     eDur: TickedDuration,
     eVel: Velocity,
     eVol: Volume,
-    eParams: List[Double]
+    eParams: List[Double],
+    eTempo: Int
 )

--- a/src/main/scala/scalamusic/performance/players/ComprehensivePlayer.scala
+++ b/src/main/scala/scalamusic/performance/players/ComprehensivePlayer.scala
@@ -54,7 +54,8 @@ object ComprehensivePlayer extends players.Player[NoteWithAttributes] {
       eDur = initialEffectiveDur,       // Effective duration (will be post-processed by Articulations)
       eVel = initialVel,                // Initial velocity (will be post-processed by Dynamics/Accents)
       eVol = c.cVol,
-      eParams = List.empty
+      eParams = List.empty,
+      eTempo = c.cTempo
     )
 
     // A Performance is a list of MusicEvents

--- a/src/main/scala/scalamusic/performance/players/Player.scala
+++ b/src/main/scala/scalamusic/performance/players/Player.scala
@@ -61,7 +61,8 @@ object DefaultPlayer extends Player[NoteWithAttributes] {
       eDur = d * c.cDur,
       eVel = c.cVel,
       eVol = c.cVol,
-      eParams = List.empty
+      eParams = List.empty,
+      eTempo = c.cTempo
     )
     List(n._2.foldRight(initEv)(nasHandler(c)))
   }
@@ -199,7 +200,8 @@ object PulsePlayer extends Player[NoteWithAttributes] {
       eDur = d * c.cDur,
       eVel = c.cVel,
       eVol = pulsifiedVolume,
-      eParams = List.empty
+      eParams = List.empty,
+      eTempo = c.cTempo
     )
     List(n._2.foldRight(initEv)(nasHandler(c)))
   }

--- a/src/test/scala/scalamusic/performance/DefaultPlayerSpec.scala
+++ b/src/test/scala/scalamusic/performance/DefaultPlayerSpec.scala
@@ -19,7 +19,7 @@ class DefaultPlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List(Volume(60), Fingering(25), Dynamics("ppp"), Params(List(1.5, 2.0))))
 
     DefaultPlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0)))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0), 120))
     )
   }
 
@@ -31,8 +31,8 @@ class DefaultPlayerSpec extends AnyFlatSpec with Matchers {
 
     DefaultPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List(), 120)
       ), hn)
     )
   }
@@ -45,8 +45,8 @@ class DefaultPlayerSpec extends AnyFlatSpec with Matchers {
 
     DefaultPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List(), 120)
       ), hn)
     )
   }
@@ -54,7 +54,7 @@ class DefaultPlayerSpec extends AnyFlatSpec with Matchers {
   private def buildContext(): Context[NoteWithAttributes] = {
     val timeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
     Context(
-      0, DefaultPlayer, AltoSax, 1, 125, 60, 60, (C, Major), timeSignature
+      0, DefaultPlayer, AltoSax, 1, 125, 60, 60, (C, Major), timeSignature, 120
     )
   }
 

--- a/src/test/scala/scalamusic/performance/FancyPlayerSpec.scala
+++ b/src/test/scala/scalamusic/performance/FancyPlayerSpec.scala
@@ -20,7 +20,7 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List(Volume(60), Fingering(25), Dynamics("ppp"), Params(List(1.5, 2.0))))
 
     FancyPlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0)))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0), 120))
     )
   }
 
@@ -32,8 +32,8 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List(), 120)
       ), hn)
     )
   }
@@ -46,8 +46,8 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 40, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 40, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List(), 120)
       ), hn)
     )
   }
@@ -60,8 +60,8 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 40, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 40, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List(), 120)
       ), hn)
     )
   }
@@ -74,9 +74,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 70, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 70, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List(), 120)
       ), dhn)
     )
   }
@@ -89,9 +89,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 100, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 100, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List(), 120)
       ), dhn)
     )
   }
@@ -104,9 +104,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 24), 60, 60, List()),
-        MusicEvent(Rational(7, 24), AltoSax, 197, Rational(3, 8), 60, 60, List()),
-        MusicEvent(Rational(2, 3), AltoSax, 197, Rational(11, 24), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 24), 60, 60, List(), 120),
+        MusicEvent(Rational(7, 24), AltoSax, 197, Rational(3, 8), 60, 60, List(), 120),
+        MusicEvent(Rational(2, 3), AltoSax, 197, Rational(11, 24), 60, 60, List(), 120)
       ), 9*en)
     )
   }
@@ -119,9 +119,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(5, 24), 60, 60, List()),
-        MusicEvent(Rational(5, 24), AltoSax, 197, en, 60, 60, List()),
-        MusicEvent(Rational(1, 3), AltoSax, 197, Rational(1, 24), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(5, 24), 60, 60, List(), 120),
+        MusicEvent(Rational(5, 24), AltoSax, 197, en, 60, 60, List(), 120),
+        MusicEvent(Rational(1, 3), AltoSax, 197, Rational(1, 24), 60, 60, List(), 120)
       ), 3*en)
     )
   }
@@ -134,9 +134,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(1, 6), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -149,9 +149,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -164,9 +164,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -179,9 +179,9 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
 
     FancyPlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 120, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 120, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120)
       ), dhn)
     )
   }
@@ -191,7 +191,7 @@ class FancyPlayerSpec extends AnyFlatSpec with Matchers {
                           ): Context[NoteWithAttributes] = {
     val timeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
     Context(
-      0, FancyPlayer, AltoSax, 1, 125, 60, cVol, (C, Major), timeSignature
+      0, FancyPlayer, AltoSax, 1, 125, 60, cVol, (C, Major), timeSignature, 120
     )
   }
 

--- a/src/test/scala/scalamusic/performance/PerformanceSpec.scala
+++ b/src/test/scala/scalamusic/performance/PerformanceSpec.scala
@@ -25,10 +25,10 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perform(c, m) should equal(
       List(
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 173, toTicks(hn), 60, 40, List()),
-        MusicEvent(toTicks(dhn), AltoSax, 173, toTicks(qn), 60, 30, List()),
-        MusicEvent(toTicks(dhn), AltoSax, 197, toTicks(qn), 60, 50, List())
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 173, toTicks(hn), 60, 40, List(), 120),
+        MusicEvent(toTicks(dhn), AltoSax, 173, toTicks(qn), 60, 30, List(), 120),
+        MusicEvent(toTicks(dhn), AltoSax, 197, toTicks(qn), 60, 50, List(), 120)
       )
     )
   }
@@ -42,10 +42,10 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 173, toTicks(hn), 60, 40, List()),
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(hn), AltoSax, 173, toTicks(hn), 60, 30, List()),
-        MusicEvent(toTicks(dhn), AltoSax, 197, toTicks(qn), 60, 50, List())
+        MusicEvent(0, AltoSax, 173, toTicks(hn), 60, 40, List(), 120),
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(hn), AltoSax, 173, toTicks(hn), 60, 30, List(), 120),
+        MusicEvent(toTicks(dhn), AltoSax, 197, toTicks(qn), 60, 50, List(), 120)
       ), toTicks(wn))
     )
   }
@@ -58,8 +58,8 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
@@ -72,8 +72,8 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 209, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AltoSax, 209, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
@@ -86,8 +86,8 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AcousticGrandPiano, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AcousticGrandPiano, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
@@ -100,8 +100,8 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
@@ -115,8 +115,8 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 120, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 120, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
@@ -129,64 +129,64 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
 
     perf(c, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List()),
-        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List())
+        MusicEvent(0, AltoSax, 197, toTicks(qn), 60, 60, List(), 120),
+        MusicEvent(toTicks(qn), AltoSax, 209, toTicks(qn), 60, 80, List(), 120)
       ), toTicks(hn))
     )
   }
 
   "merge" should "merge two performances of equal length" in {
     val p1: Performance = List(
-      MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty),
-      MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty),
-      MusicEvent(90, AltoSax, 75, 45, 60, 60, List.empty)
+      MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty, 120),
+      MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty, 120),
+      MusicEvent(90, AltoSax, 75, 45, 60, 60, List.empty, 120)
     )
     val p2: Performance = List(
-      MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty),
-      MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty),
-      MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty)
+      MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty, 120),
+      MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty, 120),
+      MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty, 120)
     )
 
     merge(p1, p2) should equal(
       List(
-        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty),
-        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(90, AltoSax, 75, 45, 60, 60, List.empty)
+        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty, 120),
+        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(90, AltoSax, 75, 45, 60, 60, List.empty, 120)
       )
     )
   }
 
   "merge" should "merge two performances of different length" in {
     val p1: Performance = List(
-      MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty),
-      MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty),
+      MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty, 120),
+      MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty, 120),
     )
     val p2: Performance = List(
-      MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty),
-      MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty),
-      MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty)
+      MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty, 120),
+      MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty, 120),
+      MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty, 120)
     )
 
     merge(p1, p2) should equal(
       List(
-        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty),
-        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty)
+        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty, 120),
+        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty, 120)
       )
     )
 
     merge(p2, p1) should equal(
       List(
-        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty),
-        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty),
-        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty)
+        MusicEvent(0, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(5, AltoSax, 75, 20, 60, 60, List.empty, 120),
+        MusicEvent(25, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(45, AltoSax, 75, 45, 60, 60, List.empty, 120),
+        MusicEvent(70, AltoSax, 75, 45, 60, 60, List.empty, 120)
       )
     )
 
@@ -195,7 +195,7 @@ class PerformanceSpec extends AnyFlatSpec with Matchers {
   private def buildContext(): Context[NoteWithAttributes] = {
     val timeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
     Context(
-      0, DefaultPlayer, AltoSax, 4 * PulsesPerQuarterNote, 125, 60, 60, (C, Major), timeSignature
+      0, DefaultPlayer, AltoSax, 4 * PulsesPerQuarterNote, 125, 60, 60, (C, Major), timeSignature, 120
     )
   }
 

--- a/src/test/scala/scalamusic/performance/PulsePlayerSpec.scala
+++ b/src/test/scala/scalamusic/performance/PulsePlayerSpec.scala
@@ -21,7 +21,7 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List(Volume(60), Fingering(25), Dynamics("ppp"), Params(List(1.5, 2.0))))
 
     PulsePlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0)))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 60, List(1.5, 2.0), 120))
     )
   }
 
@@ -32,16 +32,16 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List.empty)
 
     PulsePlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 96), d, n) should equal(
-      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 2*96), d, n) should equal(
-      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 74, List.empty))
+      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 74, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 3*96), d, n) should equal(
-      List(MusicEvent(3*96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(3*96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
   }
 
@@ -52,16 +52,16 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List.empty)
 
     PulsePlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 96), d, n) should equal(
-      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 2*96), d, n) should equal(
-      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 67, List.empty))
+      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 67, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 3*96), d, n) should equal(
-      List(MusicEvent(3*96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(3*96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
   }
 
@@ -72,13 +72,13 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
     val n: NoteWithAttributes = ((C, 5), List.empty)
 
     PulsePlayer.playNote(c, d, n) should equal(
-      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty))
+      List(MusicEvent(0, AltoSax, 197, qn, 60, 74, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 96), d, n) should equal(
-      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
     PulsePlayer.playNote(c.copy(cTime = c.cTime + 2*96), d, n) should equal(
-      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 60, List.empty))
+      List(MusicEvent(2*96, AltoSax, 197, qn, 60, 60, List.empty, 120))
     )
   }
 
@@ -90,8 +90,8 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 120, List(), 120)
       ), hn)
     )
   }
@@ -104,8 +104,8 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 40, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 40, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List(), 120)
       ), hn)
     )
   }
@@ -118,8 +118,8 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 40, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 40, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 40, List(), 120)
       ), hn)
     )
   }
@@ -132,9 +132,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 70, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 70, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List(), 120)
       ), dhn)
     )
   }
@@ -147,9 +147,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, qn, 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, qn, 60, 100, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List())
+        MusicEvent(0, AltoSax, 197, qn, 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, qn, 60, 100, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 80, List(), 120)
       ), dhn)
     )
   }
@@ -162,9 +162,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 24), 60, 60, List()),
-        MusicEvent(Rational(7, 24), AltoSax, 197, Rational(3, 8), 60, 60, List()),
-        MusicEvent(Rational(2, 3), AltoSax, 197, Rational(11, 24), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 24), 60, 60, List(), 120),
+        MusicEvent(Rational(7, 24), AltoSax, 197, Rational(3, 8), 60, 60, List(), 120),
+        MusicEvent(Rational(2, 3), AltoSax, 197, Rational(11, 24), 60, 60, List(), 120)
       ), 9*en)
     )
   }
@@ -177,9 +177,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(5, 24), 60, 60, List()),
-        MusicEvent(Rational(5, 24), AltoSax, 197, en, 60, 60, List()),
-        MusicEvent(Rational(1, 3), AltoSax, 197, Rational(1, 24), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(5, 24), 60, 60, List(), 120),
+        MusicEvent(Rational(5, 24), AltoSax, 197, en, 60, 60, List(), 120),
+        MusicEvent(Rational(1, 3), AltoSax, 197, Rational(1, 24), 60, 60, List(), 120)
       ), 3*en)
     )
   }
@@ -192,9 +192,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(1, 6), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -207,9 +207,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -222,9 +222,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List()),
-        MusicEvent(hn, AltoSax, 197, qn, 60, 60, List())
+        MusicEvent(0, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(1, 6), 60, 60, List(), 120),
+        MusicEvent(hn, AltoSax, 197, qn, 60, 60, List(), 120)
       ), dhn)
     )
   }
@@ -237,9 +237,9 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
 
     PulsePlayer.interpretPhrase(c, pas, m) should equal(
       (List(
-        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 120, List()),
-        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 120, List()),
-        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 120, List())
+        MusicEvent(0, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120),
+        MusicEvent(qn, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120),
+        MusicEvent(hn, AltoSax, 197, Rational(7, 20), 60, 120, List(), 120)
       ), dhn)
     )
   }
@@ -249,7 +249,7 @@ class PulsePlayerSpec extends AnyFlatSpec with Matchers {
                             cTimeSignature: TimeSignature = TimeSignature(NoPulse(), qn, 0)
                           ): Context[NoteWithAttributes] = {
     Context(
-      0, PulsePlayer, AltoSax, 1, 125, 60, cVol, (C, Major), cTimeSignature
+      0, PulsePlayer, AltoSax, 1, 125, 60, cVol, (C, Major), cTimeSignature, 120
     )
   }
 


### PR DESCRIPTION
… in the Context. Here's what was changed:

  1. Context.scala - Added cTempo: Int field

  - New parameter for tempo in beats per minute (BPM)

  2. MusicEvent.scala - Added eTempo: Int field

  - Each music event now carries its tempo value

  3. Player implementations - All players now pass tempo

  - DefaultPlayer, FancyPlayer, PulsePlayer, ComprehensivePlayer
  - Each creates MusicEvent instances with eTempo = c.cTempo

  4. MidiService.scala - Uses event tempo via MIDI meta events

  - Added createTempoChangeEvent() to create MIDI tempo meta events (type 0x51)
  - Added collectTempoChanges() to extract all tempo changes from performances
  - Removed hardcoded setTempoInBPM(184) call
  - Tempo changes are now embedded in the MIDI sequence itself, allowing tempo to change during playback

  5. Mambo.scala - Updated example

  - Context now includes cTempo = 184 (the previously hardcoded value)

  6. Test files - All updated

  - DefaultPlayerSpec.scala, FancyPlayerSpec.scala, PulsePlayerSpec.scala, PerformanceSpec.scala
  - All Context and MusicEvent instantiations updated with tempo parameter (120 BPM default for tests)

  7. Documentation - Updated

  - README.md - Updated Context example to show tempo parameter
  
  
8. Fixed percussion volume